### PR TITLE
Fix submillisecond precision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,3 +44,6 @@
 
 ## [1.6.1]
 - Flame graph is scaled to fit the window on open.
+
+## [1.6.2]
+- Enabled submillisecond precision in flame graphs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,4 +47,5 @@
 
 ## [1.6.2]
 - Enabled submillisecond precision in flame graphs.
-- Fixed and improved printing of date-time (unfortunately date hardcoded to 'en-GB')
+- Fixed and improved printing of flame hover boxes (unfortunately date hardcoded to 'en-GB').
+- Relaxed the default settings (allow spaces for line indentation, make log levels optional, ignore time zone offset in dates).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,3 +47,4 @@
 
 ## [1.6.2]
 - Enabled submillisecond precision in flame graphs.
+- Fixed and improved printing of date-time (unfortunately date hardcoded to 'en-GB')

--- a/extension.js
+++ b/extension.js
@@ -610,12 +610,27 @@ function drawBlock( data, min, total, level )
 	return str;
 }
 
+function toSecondsOrMilliseconds( seconds ) {
+	if (seconds >= 0.01) {
+		return seconds.toFixed(3) + 's';
+	} else {
+		return (seconds * 1000).toFixed(3) + 'ms';
+	}
+}
+
+function toPreciseString(seconds) {
+	const date = new Date(seconds * 1000);
+	const niceTime = date.toLocaleString('en-GB', { dateStyle: 'short', timeStyle: 'medium' });
+	const subseconds = seconds.toFixed(6).split('.')[1].replace(/0*$/, "");
+	return niceTime + '.' + subseconds;
+}
+
 function drawData( data ) {
 	var str = '<div class="la-data">';
 	str += '' + data.name + '\n';
-	str += 'start: ' + data.start.toFixed( 3 ) + '\n';
-	str += 'end  : ' + data.end.toFixed( 3 ) + '\n';
-	str += 'time : ' + (data.end - data.start).toFixed( 3 ) + '\n';
+	str += 'start: ' + toPreciseString(data.start * 1000) + '\n';
+	str += 'end  : ' + toPreciseString(data.end * 1000) + '\n';
+	str += 'time : ' + toSecondsOrMilliseconds(data.end - data.start) + '\n';
 	str += 'line : ' + (data.line+1) + '';
 
 	str += '</div>';

--- a/extension.js
+++ b/extension.js
@@ -39,7 +39,7 @@ function activate(context) {
 		}
 
 		const configuration = vscode.workspace.getConfiguration( "logInspector" );
-		// var regExStart = /^[0-9]{4}-[0-1][0-9]-[0-3][0-9]/;
+		// var regExStart = /^\s*[0-9]{4}-[0-1][0-9]-[0-3][0-9]/;
 		var regExStart = new RegExp( configuration.lineStart );
 
 		vscode.window.activeTextEditor.edit(editBuilder => {

--- a/extension.js
+++ b/extension.js
@@ -593,14 +593,14 @@ function drawBlock( data, min, total, level )
 	var height = 20;
 	var top = level * height;
 	var width = ( data.end - data.start ) / total;
-	var left = ( data.start - min ) / total;
+	var left = data.start / total;
 	var color = [ "#cc0000", "#008000", "#0000cc" ][ level % 3 ];
 	str += '<div style="top:' + top
 				 + 'px; left:' + left 
 				 + '%;  height:' + height 
 				 + 'px; width:' + width 
 				 + '%;  background:' + color + '" class="la-block" line="' + data.line + '">'
-				 + drawData( data )
+				 + drawData( data, min )
 				 + '</div>\n'
 
 	var calls = data.calls || [];
@@ -625,13 +625,14 @@ function toPreciseString(seconds) {
 	return niceTime + '.' + subseconds;
 }
 
-function drawData( data ) {
+function drawData( data, min ) {
 	var str = '<div class="la-data">';
 	str += '' + data.name + '\n';
-	str += 'start: ' + toPreciseString(data.start * 1000) + '\n';
-	str += 'end  : ' + toPreciseString(data.end * 1000) + '\n';
-	str += 'time : ' + toSecondsOrMilliseconds(data.end - data.start) + '\n';
-	str += 'line : ' + (data.line+1) + '';
+	str += toPreciseString(data.start + min) + '\n';
+	str += toSecondsOrMilliseconds(data.start) + ' -- start offset\n';
+	str += toSecondsOrMilliseconds(data.end) + ' -- end offset\n';
+	str += toSecondsOrMilliseconds(data.end - data.start) + ' -- duration\n';
+	str += 'line: ' + (data.line+1) + '';
 
 	str += '</div>';
 	return str;
@@ -788,8 +789,6 @@ function createData( useDates, startLine )
 	// console.log( [...ignored.keys()] )
 	// console.log( [...matchedBegins.keys()] )
 
-	ret.max = ret.max - ret.min;
-	ret.min = 0;
 	// console.log( "done" );
 	return ret;
 }

--- a/extension.js
+++ b/extension.js
@@ -1,6 +1,15 @@
 const vscode = require('vscode');
 var logEditor = null;
 
+function preciseTime(dateTime) {
+	const timeSplit = dateTime.split('.');
+	// Date is up to milliseconds, so it could handle 3 digits of timeSplit[1], but no more.
+	const seconds = new Date(timeSplit[0]) / 1000;
+	if (timeSplit.length === 0) { return seconds; }
+	const subseconds = Number(timeSplit[1]) / (10 ** timeSplit[1].length);
+	return seconds + subseconds;
+}
+
 /**
  * @param {vscode.ExtensionContext} context
  */
@@ -107,7 +116,7 @@ function activate(context) {
 			vscode.window.showWarningMessage( "Begin or end keywords not found on given line" );
 			return; // no begin or end at line
 		}
-		var startDate = new Date( match.groups.date );
+		var startDate = preciseTime( match.groups.date );
 
 		var name, back, original;
 		var done = false;
@@ -160,8 +169,8 @@ function activate(context) {
 				}
 			}
 			if ( stack.length === 0 ) {
-				var endDate = new Date( match.groups.date );
-				var duration = ( endDate.valueOf() - startDate.valueOf() ) / 1000;
+				var endDate = preciseTime( match.groups.date );
+				var duration = endDate - startDate;
 				if ( !searchForward ) {
 					duration = duration * -1;
 				}
@@ -327,7 +336,7 @@ function findClusterStart()
 		if ( !match ) {
 			continue;
 		}
-		date = (new Date( match.groups.date )).valueOf() / 1000;
+		date = preciseTime( match.groups.date );
 		if ( lastDate < 0 ) {
 			lastDate = date;
 		}
@@ -642,7 +651,7 @@ function createData( useDates, startLine )
 			if ( !match ) {
 				continue;
 			}
-			ret.min = (new Date( match.groups.date )).valueOf() / 1000;
+			ret.min = preciseTime( match.groups.date );
 			break;
 		}
 		console.log( "min: " + ret.min );
@@ -654,7 +663,7 @@ function createData( useDates, startLine )
 			if ( !match ) {
 				continue;
 			}
-			ret.max = (new Date( match.groups.date )).valueOf() / 1000;
+			ret.max = preciseTime( match.groups.date );
 			break;
 		}
 		console.log( "max: " + ret.max );
@@ -685,7 +694,7 @@ function createData( useDates, startLine )
 
 			obj = { "name" : name, "start" : line, "calls" : [], "line" : line };
 			if ( useDates ) {
-				obj.start = (new Date( match.groups.date )).valueOf() / 1000 - ret.min;
+				obj.start = preciseTime( match.groups.date ) - ret.min;
 			}
 			stack.push( obj );
 			stackNames.push( name );
@@ -710,7 +719,7 @@ function createData( useDates, startLine )
 				back = stack.pop();
 				stackNames.pop();
 				if ( useDates )  {
-					back.end = (new Date( match.groups.date )).valueOf() / 1000 - ret.min;
+					back.end = preciseTime( match.groups.date ) - ret.min;
 				}
 				else {
 					back.end = line;

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "loginspector",
 	"displayName": "Log Inspector",
 	"description": "Analyze log files to better understand the program that it describes.",
-	"version": "1.6.1",
+	"version": "1.6.2",
 	"publisher": "LogInspector",
 	"repository": {
 		"type": "git",

--- a/package.json
+++ b/package.json
@@ -52,12 +52,12 @@
 			"properties": {
 				"logInspector.lineStart": {
 					"type": "string",
-					"default": "^[0-9]{4}-[0-1][0-9]-[0-3][0-9]",
+					"default": "^\\s*[0-9]{4}-[0-1][0-9]-[0-3][0-9]",
 					"description": "A regex that matches the start of a log line. Any lines that do not start with this sequence will be considered continuations of the previous line."
 				},
 				"logInspector.lineRegex": {
 					"type": "string",
-					"default": "^(?<date>[0-9]{4}-[0-1][0-9]-[0-3][0-9]\\s[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3})\\s-\\s(t0x[0-9a-z]+\\s)?\\[(Debug[1-5]?|Warning|Error)\\]\\s*(?<body>.*)",
+					"default": "^\\s*(?<date>[0-9]{4}-[0-1][0-9]-[0-3][0-9]\\s[0-9]{2}:[0-9]{2}:[0-9]{2}\\.[0-9]+)\\s(\\+[0-9]{2}:[0-9]{2}\\s)?-\\s(t0x[0-9a-z]+\\s)?(\\[(Debug[1-5]?|Warning|Error)\\]\\s*)?(?<body>.*)",
 					"description": "A regex that matches entire log line. It should contain two named groups - 'date' and 'body'. "
 				},
 				"logInspector.truncateLine": {


### PR DESCRIPTION
The `Date` objects in JavaScript have millisecond resolution and ignore digits behind the 3rd decimal place. My suggestion handles arbitrary precision, without negatively affecting readability.
Note: I use modified regexps to recognize date-times.